### PR TITLE
Allow boxClassName to be a function

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { largestRect } from 'rect-scaler'
 
+type FunctionBoxClassNameType = (child: React.ReactNode) => string;
+
+
 interface Props {
   children: React.ReactNode
   className?: string
-  boxClassName?: string
+  boxClassName?: string | FunctionBoxClassNameType
   updateLayoutRef?: React.MutableRefObject<(() => void) | undefined>
   boxAspectRatio?: number
 }
@@ -72,7 +75,7 @@ export function PackedGrid({
   className,
   boxClassName,
   updateLayoutRef,
-  boxAspectRatio
+  boxAspectRatio,
 }: Props) {
   const [layout, setNumBoxes, updateLayout] = usePackedGridLayout(
     boxAspectRatio
@@ -105,7 +108,7 @@ export function PackedGrid({
     >
       {React.Children.map(children, (child) => (
         <div
-          className={boxClassName}
+          className={typeof boxClassName === "function" ? boxClassName(child) : boxClassName}
           style={
             layout
               ? {


### PR DESCRIPTION
Hello ! 
Thanks for your project that we really appreciate.
We faced an issue on our project, we want to have a grid with items taking specific classes ( on our case, to hide them without destroying the children from our list ) 
I changed the code for the boxClassName to allow a function that use the children as argument to determine the classes to apply to the Grid Item.

On our case we use it that way for instance : 

```
 const getBoxClassName = (children) => {
    const { streamId } = children.props;
    return clsx({
      ["hide"]: lastTalkerStreamId !== streamId,
    });
  };


      <PackedGrid
        className={clsx("packedGrid", classes.packedGrid)}
        boxAspectRatio={16 / 9}
        updateLayoutRef={packedGridRef}
        boxClassName={getBoxClassName}
      >
```